### PR TITLE
Realease 1.0.3 - download button

### DIFF
--- a/.changeset/nasty-weeks-happen.md
+++ b/.changeset/nasty-weeks-happen.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/vanilla-components': patch
+---
+
+Fixes download button filtering issues


### PR DESCRIPTION
Updates Vanilla V1 to the latest improvements - allowing the download button to correctly recognize filters.