### PR TITLE
TPS-682 - Ensure Dynamic X-Axis Value Remains When Data Updates

### DIFF
--- a/src/components/vanilla/charts/DynamicAxisBar/index.tsx
+++ b/src/components/vanilla/charts/DynamicAxisBar/index.tsx
@@ -34,10 +34,6 @@ export default (props: Props) => {
 
   const theme: Theme = useTheme() as Theme;
 
-  useEffect(() => {
-    setValue(props.xAxis.name);
-  }, [props.xAxis]);
-
   const xAxisOptions = props.xAxisOptions?.find((item) => props.xAxis.name == item.name)
     ? props.xAxisOptions
     : [...(props.xAxisOptions || []), props.xAxis];
@@ -84,7 +80,9 @@ export default (props: Props) => {
         </div>
       </div>
       <div className="flex grow overflow-hidden">
-        {results.isLoading || !xAxis || !results?.data?.filter((_,i) => i < 10)?.some((row) => row[xAxis.name]) ? null : (
+        {results.isLoading ||
+        !xAxis ||
+        !results?.data?.filter((_, i) => i < 10)?.some((row) => row[xAxis.name]) ? null : (
           <BarChart key={value} {...updatedProps} />
         )}
       </div>

--- a/src/components/vanilla/charts/DynamicAxisBar/index.tsx
+++ b/src/components/vanilla/charts/DynamicAxisBar/index.tsx
@@ -34,7 +34,7 @@ export default (props: Props) => {
 
   const theme: Theme = useTheme() as Theme;
 
-  const xAxisOptions = props.xAxisOptions?.find((item) => props.xAxis.name == item.name)
+  const xAxisOptions = props.xAxisOptions?.find((item) => props.xAxis.name === item.name)
     ? props.xAxisOptions
     : [...(props.xAxisOptions || []), props.xAxis];
 


### PR DESCRIPTION
**Description**
Updating the dynamic axis bar chart then changing the data caused it to revert to the original x-axis value even though the dropdown still showed the new one (this also prevented the bar chart from display). See here for more: https://trevorio.atlassian.net/issues/TPS-682

**Fix**
There was a useEffect running every time the x-axis changed resetting it to the props value ... but that was running whenever the data changed because by default it sends a new set of props when new data is pulled in. It's not needed since we run the same setValue command when the dropdown changes anyway. This way we retain the selected item between data changes, which is the experience a user would expect.

**Acceptance Criteria**
 - [x] Bug is fixed
 - [x] Bar Chart otherwise behaves the same as it used to