### PR TITLE
TPS-677 - Dropdown Blurs When Scroll is Dragged, Menu Closes

### DIFF
--- a/src/components/vanilla/controls/Dropdown/index.tsx
+++ b/src/components/vanilla/controls/Dropdown/index.tsx
@@ -195,6 +195,12 @@ export default (props: Props) => {
               border-[color:--embeddable-controls-borders-colors-normal]
               rounded-[--embeddable-controls-borders-radius]
             `}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              // re-focus the input (allows repeated clicking in and out)
+              ref.current?.focus();
+              setTriggerBlur(false);
+            }}
           >
             {list}
             {list?.length === 0 && !!search && (

--- a/src/components/vanilla/controls/MultiSelectDropdown/index.tsx
+++ b/src/components/vanilla/controls/MultiSelectDropdown/index.tsx
@@ -209,6 +209,12 @@ export default (props: Props) => {
               bg-[color:--embeddable-controls-backgrounds-colors-soft]
               rounded-[--embeddable-controls-borders-radius]
             `}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              // re-focus the input (allows repeated clicking in and out)
+              ref.current?.focus();
+              setTriggerBlur(false);
+            }}
           >
             {list}
             {list?.length === 0 && !!search && (


### PR DESCRIPTION
**Description**
Currently the dropdown list works fine with the scrollwheel or touchpad, but if you actually click and drag with the scrollbar, it triggers a blur on the input, which in turn shuts the menu after 500ms. This happens because the scrollbar is in a container div, rather than in the input itself, so clicking on it blurs the input.

**Fix**
Add an `onMouseDown` event to the container div that sets the state to not trigger the menu close. I also added a line that refocuses the input, which means you can click on and off and on again without closing the menu (assuming you can do it faster than 500ms), but if you click off and wait 500ms, it will close as expected.

**Acceptance Criteria**
 - [x] Clicking the scrollbar and dragging works as expected
 - [x] Dropdown otherwise behaves as it did before
  