### PR TITLE
CS-66 - Dropdowns Not Recognizing Second Click

### DIFF
--- a/src/components/vanilla/controls/Dropdown/index.tsx
+++ b/src/components/vanilla/controls/Dropdown/index.tsx
@@ -95,7 +95,7 @@ export default (props: Props) => {
             key={i}
             onClick={() => {
               setFocus(false);
-              setTriggerBlur(false);
+              setTriggerBlur(true);
               set(o[props.property?.name || ''] || '');
             }}
             className={`flex items-center min-h-[36px] px-3 py-2 hover:bg-black/5 cursor-pointer font-normal ${
@@ -138,6 +138,10 @@ export default (props: Props) => {
           value={search}
           name="dropdown"
           placeholder={props.placeholder}
+          onClick={(e) => {
+            setFocus(true);
+            setTriggerBlur(false);
+          }}
           onFocus={() => setFocus(true)}
           onBlur={() => setTriggerBlur(true)}
           onChange={(e) => performSearch(e.target.value)}


### PR DESCRIPTION
** Description **

Due to the fix for the scrollbar issue on dropdowns (where dragging the scrollbar would cause a `blur` and the window would shut while you were dragging), once you selected an option, you could not open the dropdown again unless you clicked somewhere else on the page. This was annoying and confusing. It's now fixed.

** Acceptance Criteria **
 - [x] Dropdown opens with subsequent clicks without the need to click elsewhere on the page
 - [x] Dragging the scrollbar is still fixed 