### PR TITLE
CS-67 - Line Chart Axis

### DIFF
--- a/src/components/vanilla/charts/CompareLineChart/CompareLineChart.emb.ts
+++ b/src/components/vanilla/charts/CompareLineChart/CompareLineChart.emb.ts
@@ -28,6 +28,16 @@ export const meta = {
       category: 'Chart data',
     },
     {
+      name: 'comparisonXAxis',
+      type: 'dimension',
+      label: 'Comparison X-Axis (optional)',
+      config: {
+        dataset: 'ds',
+        supportedTypes: ['time'],
+      },
+      category: 'Chart data',
+    },
+    {
       name: 'metrics',
       type: 'measure',
       array: true,
@@ -77,6 +87,14 @@ export const meta = {
       type: 'string',
       label: 'X-Axis Title',
       category: 'Chart settings',
+    },
+    {
+      name: 'comparisonXAxisTitle',
+      type: 'string',
+      label: 'Comparison X-Axis Title (optional)',
+      description: 'Title for the comparison X-Axis',
+      category: 'Chart settings',
+      defaultValue: '',
     },
     {
       name: 'yAxisTitle',
@@ -154,6 +172,14 @@ export default defineComponent(Component, meta, {
             dimension: inputs.xAxis?.name,
             granularity: inputs.granularity,
           },
+          ...(inputs.comparisonXAxis
+            ? [
+                {
+                  dimension: inputs.comparisonXAxis.name,
+                  granularity: inputs.granularity,
+                },
+              ]
+            : []),
         ],
         measures: inputs.metrics,
         filters:

--- a/src/components/vanilla/charts/CompareLineChart/index.tsx
+++ b/src/components/vanilla/charts/CompareLineChart/index.tsx
@@ -53,12 +53,14 @@ type Props = {
   title?: string;
   ds: Dataset;
   xAxis: Dimension;
+  comparisonXAxis?: Dimension;
   granularity: Granularity;
   metrics: Measure[];
   timeFilter?: TimeRange;
   prevTimeFilter?: TimeRange;
   yAxisMin?: number;
   xAxisTitle?: string;
+  comparisonXAxisTitle?: string;
   yAxisTitle?: string;
   applyFill?: boolean;
   showLabels?: boolean;
@@ -123,7 +125,7 @@ export default (propsInitial: Props) => {
           data: props.prevTimeFilter
             ? prevData?.map((d: Record) => ({
                 y: parseFloat(d[metrics[i].name] || '0'),
-                x: parseTime(d[props.xAxis?.name || '']),
+                x: parseTime(d[props.comparisonXAxis?.name || '']),
               })) || []
             : [],
           backgroundColor: applyFill
@@ -209,7 +211,7 @@ export default (propsInitial: Props) => {
         comparison: {
           min: bounds.comparison?.from?.toJSON(),
           max: bounds.comparison?.to?.toJSON(),
-          display: false,
+          display: !!props.comparisonXAxis,
           grid: {
             display: false,
           },
@@ -221,7 +223,8 @@ export default (propsInitial: Props) => {
             unit: props.granularity,
           },
           title: {
-            display: false,
+            display: !!props.comparisonXAxisTitle,
+            text: props.comparisonXAxisTitle,
           },
         },
       },


### PR DESCRIPTION
**Description**
Adds a second, optional x-axis to the Comparison Line Chart so that users can see the dates for both the period and comparison values.

**Acceptance Criteria**
 - [x] Users can add a second x-axis and have it display accurately in conjunction with the comparison data
 - [x] Users can give the second x-axis a title if they want to
 - [x] Chart behaves as expected with second x-axis
 - [x] Chart behaves as expected _without_ second x-axis