### PR TITLE
TPS-721 - Handle pie chart labels that are booleans

### DIFF
--- a/src/components/vanilla/charts/PieChart/index.tsx
+++ b/src/components/vanilla/charts/PieChart/index.tsx
@@ -151,6 +151,10 @@ function chartOptions(props: Props): ChartOptions<'pie'> {
         callbacks: {
           label: function (context) {
             let label = context.dataset.label || '';
+            // handle labels that are booleans
+            if (typeof context.dataset.label === 'boolean') {
+              label = context.dataset.label ? 'True' : 'False';
+            }
             if (context.parsed !== null) {
               label += `: ${formatValue(`${context.parsed || ''}`, {
                 type: 'number',


### PR DESCRIPTION
**description**
A customer noticed at when using a pie chart with boolean values, the tooltip label would show "true" for true, but nothing for "false". The reason is this line:
```
let label = context.dataset.label || '';
```
Because if `label` is `false`, it just sets an empty string. So I added an additional few lines to explicitly check for boolean values. I tried a few different ways of structuring the code, but this was the shortest working version.