### PR TITLE
Potential fix for time series line chart axis bug

### DIFF
--- a/src/components/vanilla/charts/CompareLineChart/CompareLineChart.emb.ts
+++ b/src/components/vanilla/charts/CompareLineChart/CompareLineChart.emb.ts
@@ -172,14 +172,6 @@ export default defineComponent(Component, meta, {
             dimension: inputs.xAxis?.name,
             granularity: inputs.granularity,
           },
-          ...(inputs.comparisonXAxis
-            ? [
-                {
-                  dimension: inputs.comparisonXAxis.name,
-                  granularity: inputs.granularity,
-                },
-              ]
-            : []),
         ],
         measures: inputs.metrics,
         filters:


### PR DESCRIPTION
This logic, which I added while adding a second X-Axis, isn't necessary and may be breaking some data loading for one of our clients. Removing it so I can publish and check, as I'm unable to duplicate the issue with our sample data (but I can confirm that this code removal has no impact on how the component functions locally)