### PR TITLE
EM-1885: Vanilla Components Package Shows Security Errors When Imported

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@embeddable.com/vanilla-components",
-  "version": "1.0.7",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/vanilla-components",
-      "version": "1.0.7",
+      "version": "1.0.10",
       "dependencies": {
         "@cubejs-backend/api-gateway": "^1.1.2",
         "@headlessui/tailwindcss": "^0.2.0",
@@ -32,7 +32,7 @@
         "react-day-picker": "^9.2.1",
         "react-leaflet": "^4.2.1",
         "react-leaflet-markercluster": "^4.1.1",
-        "react-simple-maps": "^3.0.0",
+        "react-simple-maps": "^4.0.0-beta.6",
         "styled-components": "^6.1.14",
         "tailwind-merge": "^2.2.1",
         "tinycolor2": "^1.6.0",
@@ -6292,15 +6292,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-drag/node_modules/d3-selection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -6360,10 +6351,13 @@
       }
     },
     "node_modules/d3-selection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
-      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
-      "license": "BSD-3-Clause"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-time": {
       "version": "3.1.0",
@@ -12206,14 +12200,14 @@
       }
     },
     "node_modules/react-simple-maps": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-simple-maps/-/react-simple-maps-3.0.0.tgz",
-      "integrity": "sha512-vKNFrvpPG8Vyfdjnz5Ne1N56rZlDfHXv5THNXOVZMqbX1rWZA48zQuYT03mx6PAKanqarJu/PDLgshIZAfHHqw==",
+      "version": "4.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/react-simple-maps/-/react-simple-maps-4.0.0-beta.6.tgz",
+      "integrity": "sha512-PVKah7p9AgmAesKTijIzUHP1iSq7FTpuY5g8DixKZWkIEvNLjL/gjPok9iqhIS6gmw6aziQxNSQ/C6umZwMePg==",
       "license": "MIT",
       "dependencies": {
-        "d3-geo": "^2.0.2",
-        "d3-selection": "^2.0.0",
-        "d3-zoom": "^2.0.0",
+        "d3-geo": "^3.1.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
         "topojson-client": "^3.1.0"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-day-picker": "^9.2.1",
     "react-leaflet": "^4.2.1",
     "react-leaflet-markercluster": "^4.1.1",
-    "react-simple-maps": "^3.0.0",
+    "react-simple-maps": "^4.0.0-beta.6",
     "styled-components": "^6.1.14",
     "tailwind-merge": "^2.2.1",
     "tinycolor2": "^1.6.0",
@@ -63,15 +63,6 @@
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.26.0",
     "@rollup/rollup-win32-x64-msvc": "4.24.4"
-  },
-  "overrides": {
-    "react-simple-maps": {
-      "d3-color": "^3.1.0",
-      "d3-geo": "^3.1.0",
-      "d3-interpolate": "^3.0.1",
-      "d3-select": "^3.0.0",
-      "d3-zoom": "^3.0.0"
-    }
   },
   "devDependencies": {
     "@changesets/cli": "^2.28.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Visit https://aka.ms/tsconfig to read more about this file */
 
     /* Language and Environment */
-    "target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "jsx": "preserve" /* Specify what JSX code is generated. */,
 
     /* Modules */


### PR DESCRIPTION
# Description
Upgraded react-simple-maps to beta version with React 18 support and removed dependency overrides

# Main changes
- Updated `react-simple-maps` from `^3.0.0` to `^4.0.0-beta.6`
- Removed `overrides` section for react-simple-maps dependencies
- Bumped TypeScript target from `es2021` to `es2022`

More information: https://trevorio.atlassian.net/browse/EM-1885?focusedCommentId=24486

# Test evidence
https://drive.google.com/file/d/1UXhpKyrD0Mb1wY-cTskkwStYjGk96ljU/view?usp=sharing
