### PR TITLE
Fix common.ts Font Error

### DIFF
--- a/src/themes/defaulttheme.ts
+++ b/src/themes/defaulttheme.ts
@@ -77,6 +77,9 @@ export const defaultTheme: Theme = {
     stackedArea: {
       cubicInterpolationMode: 'default',
       lineTension: 0.1,
+      font: {
+        size: 12,
+      },
     },
     /* End custom chart overrides */
   },

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -100,6 +100,9 @@ export type Theme = {
     stackedArea: {
       cubicInterpolationMode: 'monotone' | 'default';
       lineTension: number;
+      font: {
+        size: number;
+      };
     };
   };
   container: {


### PR DESCRIPTION
Adding the stacked area chart to the theme caused an issue with `common.ts` where it was looking for a font value and causing the build to fail. This adds that font value.