### PR TITLE
CS-68 - Add 'previous week' selector to granularity in time comparison filter

### DIFF
--- a/src/components/vanilla/controls/DatePicker/utils/dateUtils.ts
+++ b/src/components/vanilla/controls/DatePicker/utils/dateUtils.ts
@@ -37,6 +37,10 @@ export function getComparisonOptions(period: TimeRange) {
       note: getNote(subDays(period.from, days), subDays(period.to, days)),
     },
     {
+      value: 'Previous week',
+      note: getNote(subDays(period.to, 13), subDays(period.to, 7)),
+    },
+    {
       value: 'Previous month',
       note: getNote(subMonths(period.from, 1), subMonths(period.to, 1)),
     },
@@ -57,6 +61,13 @@ export function getComparisonPeriod(rts: string, period: TimeRange) {
       relativeTimeString: 'No comparison',
       from: new Date(),
       to: new Date(),
+    };
+  }
+  if (rts === 'Previous week') {
+    return {
+      relativeTimeString: 'previous week',
+      from: subDays(period.to, 13),
+      to: subDays(period.to, 7),
     };
   }
   if (rts === 'Previous month') {

--- a/src/components/vanilla/controls/DatePicker/utils/dateUtils.ts
+++ b/src/components/vanilla/controls/DatePicker/utils/dateUtils.ts
@@ -32,7 +32,7 @@ export function getComparisonOptions(period: TimeRange) {
 
   let weekNote = '';
   if (days > 7) {
-    // We have to use "to" for both, here, because otherwise it produces more than 7 days
+    // We have to use "from" for both, here, because otherwise it produces more than 7 days
     weekNote = getNote(subDays(period.from, 7), subDays(period.from, 1));
   } else {
     // If the period is less than 7 days, we can give the exact spread from the previous week

--- a/src/components/vanilla/controls/DatePicker/utils/dateUtils.ts
+++ b/src/components/vanilla/controls/DatePicker/utils/dateUtils.ts
@@ -30,6 +30,15 @@ export function getComparisonOptions(period: TimeRange) {
 
   const days = Math.abs(differenceInCalendarDays(period.from, period.to)) + 1;
 
+  let weekNote = '';
+  if (days > 7) {
+    // We have to use "to" for both, here, because otherwise it produces more than 7 days
+    weekNote = getNote(subDays(period.from, 7), subDays(period.from, 1));
+  } else {
+    // If the period is less than 7 days, we can give the exact spread from the previous week
+    weekNote = getNote(subDays(period.from, 7), subDays(period.to, 7));
+  }
+
   return [
     { value: 'No comparison' },
     {
@@ -38,7 +47,7 @@ export function getComparisonOptions(period: TimeRange) {
     },
     {
       value: 'Previous week',
-      note: getNote(subDays(period.to, 13), subDays(period.to, 7)),
+      note: weekNote,
     },
     {
       value: 'Previous month',
@@ -64,10 +73,14 @@ export function getComparisonPeriod(rts: string, period: TimeRange) {
     };
   }
   if (rts === 'Previous week') {
+    // Same calculation here, in order to keep the range consistent with the options
+    const days = Math.abs(differenceInCalendarDays(period.from, period.to)) + 1;
+    const from = subDays(period.from, 7);
+    const to = days > 7 ? subDays(period.from, 1) : subDays(period.to, 7);
     return {
       relativeTimeString: 'previous week',
-      from: subDays(period.to, 13),
-      to: subDays(period.to, 7),
+      from,
+      to,
     };
   }
   if (rts === 'Previous month') {

--- a/src/types/TimeComparison.type.emb.ts
+++ b/src/types/TimeComparison.type.emb.ts
@@ -2,11 +2,12 @@ import { defineOption, defineType } from '@embeddable.com/core';
 
 const TimeComparisonType = defineType('timeComparison', {
   label: 'Time Comparison',
-  optionLabel: (value) => value
+  optionLabel: (value) => value,
 });
 
 defineOption(TimeComparisonType, 'No comparison');
 defineOption(TimeComparisonType, 'Previous period');
+defineOption(TimeComparisonType, 'Previous week');
 defineOption(TimeComparisonType, 'Previous month');
 defineOption(TimeComparisonType, 'Previous quarter');
 defineOption(TimeComparisonType, 'Previous year');


### PR DESCRIPTION
One of our clients asked for a "previous week" selector in the granularity of the time comparison filter. So we added it!

**Picker - Less than seven days - show the same span but a week ago**

<img width="816" alt="image" src="https://github.com/user-attachments/assets/6ba570e9-ed0b-420b-a6cd-18f1b8a3a49e" />

**Result - Less than seven days - show the same span but a week ago**

<img width="1442" alt="image" src="https://github.com/user-attachments/assets/68e29219-fda2-445d-a91e-5da29bdf88eb" />

**Picker - More than seven days - show the week preceding the start of the span**

<img width="812" alt="image" src="https://github.com/user-attachments/assets/5cbc6099-6252-440f-9846-fda444b04773" />

**Result - More than seven days - show the week preceding the start of the span**

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/c1072160-271a-491b-a8c6-7ffe64547b24" />

We're aware this is a bit strange, but it's the best behavior if we want "previous week" to cap at a week long, rather than behaving the same way as "previous period". This is unlikely to be used often, but the first example is likely to get used a lot.