### PR TITLE
CS-27 - Support Markdown in Table Links

### DIFF
--- a/src/components/util/format.ts
+++ b/src/components/util/format.ts
@@ -55,6 +55,6 @@ export const detectAndReturnLinks = (text: string) => {
   if (!text) {
     return { linkText: null, linkUrl: null };
   }
-  const linkData = /\[(.*)\]\((.*)\)/g.exec(text);
+  const linkData = /\[(.*)\]\((.*)\)/.exec(text);
   return { linkText: linkData?.[1], linkUrl: encodeURI(linkData?.[2] || '') };
 };

--- a/src/components/util/format.ts
+++ b/src/components/util/format.ts
@@ -50,3 +50,11 @@ export default function formatValue(str: string = '', opt: Type | Options = 'str
     return `${meta?.pretext || ''}${v}${meta?.posttext || ''}`;
   }
 }
+
+export const detectAndReturnLinks = (text: string) => {
+  if (!text) {
+    return { linkText: null, linkUrl: null };
+  }
+  const linkData = /\[(.*)\]\((.*)\)/g.exec(text);
+  return { linkText: linkData?.[1], linkUrl: encodeURI(linkData?.[2] || '') };
+};

--- a/src/components/vanilla/charts/TableChart/index.tsx
+++ b/src/components/vanilla/charts/TableChart/index.tsx
@@ -158,7 +158,7 @@ export default (props: Props) => {
                             : 'auto',
                         }}
                       >
-                        <span title={title}>{formatColumn(row[column.name], column)}</span>
+                        <span title={title}>{formattedValue}</span>
                       </td>
                     );
                   })}

--- a/src/components/vanilla/charts/TableChart/index.tsx
+++ b/src/components/vanilla/charts/TableChart/index.tsx
@@ -138,7 +138,6 @@ export default (props: Props) => {
             <tbody>
               {results?.data?.slice(0, maxRowsFit).map((row, index) => (
                 <tr key={index} className="hover:bg-gray-400/5">
-                  const
                   {columns.map((column, index) => {
                     const formattedValue = formatColumn(row[column.name], column);
                     let title = '';

--- a/src/components/vanilla/charts/TableChart/index.tsx
+++ b/src/components/vanilla/charts/TableChart/index.tsx
@@ -6,7 +6,7 @@ import Container from '../../Container';
 import Pagination from './components/Pagination';
 import TableHead from './components/TableHead';
 import downloadAsCSV from '../../../util/downloadAsCSV';
-import formatValue from '../../../util/format';
+import formatValue, { detectAndReturnLinks } from '../../../util/format';
 import { SortDirection } from '../../../../enums/SortDirection';
 import { Theme } from '../../../../themes/theme';
 
@@ -178,6 +178,16 @@ function formatColumn(text: string | number, column: DimensionOrMeasure) {
   }
 
   if (text && column.nativeType === 'time') return formatValue(text, 'date');
+
+  // detect links - we can't do this in the format function because it returns a dom element
+  const { linkText, linkUrl } = detectAndReturnLinks(text);
+  if (linkText && linkUrl) {
+    return (
+      <a href={linkUrl} target="_blank" rel="noopener noreferrer">
+        {linkText}
+      </a>
+    );
+  }
 
   return formatValue(text);
 }

--- a/src/components/vanilla/charts/TableChart/index.tsx
+++ b/src/components/vanilla/charts/TableChart/index.tsx
@@ -138,20 +138,31 @@ export default (props: Props) => {
             <tbody>
               {results?.data?.slice(0, maxRowsFit).map((row, index) => (
                 <tr key={index} className="hover:bg-gray-400/5">
-                  {columns.map((column, index) => (
-                    <td
-                      key={index}
-                      className="text-dark p-3 truncate"
-                      style={{
-                        fontSize: props.fontSize ? `${props.fontSize}px` : theme.font.size,
-                        maxWidth: props.minColumnWidth ? `${props.minColumnWidth * 1.2}px` : 'auto',
-                      }}
-                    >
-                      <span title={formatColumn(row[column.name], column) ?? ''}>
-                        {formatColumn(row[column.name], column)}
-                      </span>
-                    </td>
-                  ))}
+                  const
+                  {columns.map((column, index) => {
+                    const formattedValue = formatColumn(row[column.name], column);
+                    let title = '';
+                    if (typeof formattedValue === 'object') {
+                      // It's a link, so we just want the link text as the title
+                      title = (formattedValue as React.ReactElement).props.children;
+                    } else {
+                      title = formattedValue;
+                    }
+                    return (
+                      <td
+                        key={index}
+                        className="text-dark p-3 truncate"
+                        style={{
+                          fontSize: props.fontSize ? `${props.fontSize}px` : theme.font.size,
+                          maxWidth: props.minColumnWidth
+                            ? `${props.minColumnWidth * 1.2}px`
+                            : 'auto',
+                        }}
+                      >
+                        <span title={title}>{formatColumn(row[column.name], column)}</span>
+                      </td>
+                    );
+                  })}
                 </tr>
               ))}
             </tbody>

--- a/src/models/cubes/products.cube.yml
+++ b/src/models/cubes/products.cube.yml
@@ -27,13 +27,19 @@ cubes:
         type: sum
         title: Total USD
         sql: price_usd
-        meta: 
+        meta:
           pretext: '$'
           posttext: ''
 
+      - name: link_to_product
+        sql: FORMAT('[%s](%s)', name, 'https://www.google.com/search?q='||name)
+        type: string
+        meta:
+          link: true
+
     joins:
       - name: orders # the name of the data model to join to (not the table)
-        sql: "{CUBE}.id = {orders}.product_id"
+        sql: '{CUBE}.id = {orders}.product_id'
         relationship: one_to_many
 
     pre_aggregations:


### PR DESCRIPTION
**Description**

Checks all table column values to see if any of them are markdown formatted links. If so, it returns an anchor dom element with the appropriate text/href, rather than just plain text.

I went ahead and left the sample link measure in the model file, as it may be useful for us down the line when testing other things

**Acceptance Criteria**
 
 - [x] Works
 - [x] Code makes sense 

**Screenshot**

Browser showing that the text is an active link (see bottom left corner)

<img width="1294" height="304" alt="image" src="https://github.com/user-attachments/assets/2b028be0-9ece-4c18-9608-7e00f4a158e5" />
