### PR TITLE
Fix - Bar Chart Granularity

### DIFF
--- a/src/components/vanilla/charts/BarChart/components/BarChart.tsx
+++ b/src/components/vanilla/charts/BarChart/components/BarChart.tsx
@@ -50,7 +50,6 @@ type Props = {
   xAxis: Dimension;
   xAxisTitle?: string;
   yAxisTitle?: string;
-  granularity?: Granularity;
   showSecondYAxis?: boolean;
   secondAxisTitle?: string;
   theme: Theme;
@@ -68,7 +67,8 @@ export default function BarChart({ ...props }: Props): React.JSX.Element {
 }
 
 function chartData(props: Props): ChartData<'bar' | 'line'> {
-  const { results, xAxis, metrics, granularity, lineMetrics, showSecondYAxis, theme } = props;
+  const { results, xAxis, metrics, lineMetrics, showSecondYAxis, theme } = props;
+  const granularity = xAxis?.inputs?.granularity as Granularity | undefined;
   const {
     charts: { colors },
     dateFormats,
@@ -81,7 +81,7 @@ function chartData(props: Props): ChartData<'bar' | 'line'> {
     chartColors = theme.charts.bar.colors;
   }
 
-  let dateFormat: string | undefined;
+  let dateFormat: string = 'yyyy-mm-dd';
   if (xAxis.nativeType === 'time' && granularity) {
     dateFormat = dateFormats[granularity];
   }

--- a/src/components/vanilla/charts/BarChart/components/BarChart.tsx
+++ b/src/components/vanilla/charts/BarChart/components/BarChart.tsx
@@ -68,7 +68,7 @@ export default function BarChart({ ...props }: Props): React.JSX.Element {
 
 function chartData(props: Props): ChartData<'bar' | 'line'> {
   const { results, xAxis, metrics, lineMetrics, showSecondYAxis, theme } = props;
-  const granularity = xAxis?.inputs?.granularity as Granularity | undefined;
+  const granularity = xAxis?.inputs?.granularity;
   const {
     charts: { colors },
     dateFormats,


### PR DESCRIPTION
- Bar chart respects granularity sub input
- Bar chart has a default date format if granularity isn't set, instead of displaying the entire UTC string