### PR TITLE
TPS-837: Handle labels in BarChart for both time dimension and non-time dimension

### DIFF
--- a/.changeset/red-pans-help.md
+++ b/.changeset/red-pans-help.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/vanilla-components': patch
+---
+
+Fix labels for non-time dimensions on Bar Chart

--- a/src/components/vanilla/charts/BarChart/components/BarChart.tsx
+++ b/src/components/vanilla/charts/BarChart/components/BarChart.tsx
@@ -80,19 +80,18 @@ function chartData(props: Props): ChartData<'bar' | 'line'> {
   if (theme.charts.bar.colors) {
     chartColors = theme.charts.bar.colors;
   }
+const isTimeDimension = xAxis?.nativeType === 'time';
 
-  let dateFormat: string = 'yyyy-mm-dd';
-  if (xAxis.nativeType === 'time' && granularity) {
-    dateFormat = dateFormats[granularity];
-  }
+  const dateFormat: string =
+    isTimeDimension && granularity ? dateFormats[granularity] : 'yyyy-mm-dd';
 
   const labels = [
     ...new Set(
       results?.data?.map((d: { [p: string]: string }) => {
         const value = d[xAxis?.name];
-        return formatValue(value === null ? '' : value, {
+        return formatValue(value ?? '', {
           meta: xAxis?.meta,
-          dateFormat: dateFormat,
+          ...(isTimeDimension ? { dateFormat: dateFormat } : {}),
         });
       }),
     ),

--- a/src/components/vanilla/charts/BarChart/components/BarChart.tsx
+++ b/src/components/vanilla/charts/BarChart/components/BarChart.tsx
@@ -91,7 +91,7 @@ const isTimeDimension = xAxis?.nativeType === 'time';
         const value = d[xAxis?.name];
         return formatValue(value ?? '', {
           meta: xAxis?.meta,
-          ...(isTimeDimension ? { dateFormat: dateFormat } : {}),
+          ...(isTimeDimension ? { dateFormat } : {}),
         });
       }),
     ),


### PR DESCRIPTION
# Description
This is fix for the following [TPS ticket](https://trevorio.atlassian.net/browse/TPS-837)

The changes maintain existing functionality while handling labels for both time dimension and non-time dimension as well

# Main changes
- Add `dateFormat` to metadata for only time dimensions
- Extract time dimension condition into `isTimeDimension` variable for better readability
- Simplify `dateFormat` assignment using ternary operator instead of if/else block  
- Replace explicit null check with nullish coalescing operator (`??`) for cleaner value handling

# Test Evidence
https://drive.google.com/file/d/1wHM05Wu4CZN5cidV5DbZPqxJvtqumoea/view?usp=sharing