### PR TITLE
Add sorting to select / multiselect

### DIFF
--- a/src/components/vanilla/controls/MultiSelectDropdown/MultiSelectDropdown.emb.ts
+++ b/src/components/vanilla/controls/MultiSelectDropdown/MultiSelectDropdown.emb.ts
@@ -1,4 +1,4 @@
-import { Value, loadData } from '@embeddable.com/core';
+import { DimensionOrMeasure, OrderBy, OrderDirection, Value, loadData } from '@embeddable.com/core';
 import { EmbeddedComponentMeta, Inputs, defineComponent } from '@embeddable.com/react';
 
 import Component, { Props } from './index';
@@ -16,44 +16,60 @@ export const meta = {
       type: 'dataset',
       label: 'Dataset',
       description: 'Dataset',
-      category: 'Dropdown values'
+      category: 'Dropdown values',
     },
     {
       name: 'property',
       type: 'dimension',
       label: 'Property',
       config: {
-        dataset: 'ds'
+        dataset: 'ds',
       },
-      category: 'Dropdown values'
+      category: 'Dropdown values',
+    },
+    {
+      name: 'sortBy',
+      type: 'dimensionOrMeasure',
+      label: 'Optional Sort By Additional Dimension or Measure',
+      config: {
+        dataset: 'ds',
+      },
+      category: 'Dropdown values',
+    },
+    {
+      name: 'sortByDirection',
+      type: 'string',
+      label: 'Sort By Direction (asc/desc)',
+      defaultValue: 'asc',
+      category: 'Dropdown values',
     },
     {
       name: 'title',
       type: 'string',
       label: 'Title',
-      category: 'Settings'
+      category: 'Settings',
     },
     {
       name: 'defaultValue',
       type: 'string',
       array: true,
       label: 'Default value',
-      category: 'Pre-configured variables'
+      category: 'Pre-configured variables',
     },
     {
       name: 'placeholder',
       type: 'string',
       label: 'Placeholder',
       defaultValue: 'Select...',
-      category: 'Settings'
+      category: 'Settings',
     },
     {
       name: 'limit',
       type: 'number',
       label: 'Default number of options',
       defaultValue: 100,
-      category: 'Settings'
-    }
+      category: 'Settings',
+    },
   ],
   events: [
     {
@@ -63,10 +79,10 @@ export const meta = {
         {
           name: 'value',
           type: 'string',
-          array: true
-        }
-      ]
-    }
+          array: true,
+        },
+      ],
+    },
   ],
   variables: [
     {
@@ -75,9 +91,9 @@ export const meta = {
       defaultValue: Value.noFilter(),
       array: true,
       inputs: ['defaultValue'],
-      events: [{ name: 'onChange', property: 'value' }]
-    }
-  ]
+      events: [{ name: 'onChange', property: 'value' }],
+    },
+  ],
 } as const satisfies EmbeddedComponentMeta;
 
 export default defineComponent<Props, typeof meta, { search: string }>(Component, meta, {
@@ -85,33 +101,53 @@ export default defineComponent<Props, typeof meta, { search: string }>(Component
     if (!inputs.ds)
       return {
         ...inputs,
-        options: [] as never
+        options: [] as never,
       };
+
+    const orderProp: OrderBy[] = [];
+    let sortByDirection = 'asc' as OrderDirection;
+    if (inputs.sortByDirection === 'desc' || inputs.sortByDirection === 'asc') {
+      sortByDirection = inputs.sortByDirection as OrderDirection;
+    }
+    const sortDirection = sortByDirection;
+
+    if (inputs.sortBy) {
+      orderProp.push({
+        property: inputs.sortBy,
+        direction: sortDirection,
+      });
+    }
+
+    const select: DimensionOrMeasure[] = inputs.property ? [inputs.property] : [];
+    if (inputs.sortBy) {
+      select.push(inputs.sortBy);
+    }
 
     return {
       ...inputs,
       options: loadData({
         from: inputs.ds,
-        dimensions: inputs.property ? [inputs.property] : [],
+        select,
         limit: inputs.limit || 1000,
+        orderBy: orderProp,
         filters:
           embState?.search && inputs.property
             ? [
                 {
                   operator: 'contains',
                   property: inputs.property,
-                  value: embState?.search
-                }
+                  value: embState?.search,
+                },
               ]
-            : undefined
-      })
+            : undefined,
+      }),
     };
   },
   events: {
     onChange: (value) => {
       return {
-        value: value.length ? value : Value.noFilter()
+        value: value.length ? value : Value.noFilter(),
       };
-    }
-  }
+    },
+  },
 });


### PR DESCRIPTION
We have a client who would like to be able to sort their dropdowns by a dimension or measure other than the one that actually populates the dropdown. This allows them to do so. We have [an EM ticket](https://trevorio.atlassian.net/browse/EM-2074?atlOrigin=eyJpIjoiODM3ZGM2NWE4YmZmNGE0ODg2MDNhNDliYzQ4YmRjMTMiLCJwIjoiamlyYS1zbGFjay1pbnQifQ) already which would allow us to use the built-in sort functionality to do this, so when that goes live we should be able to revert this change, but it hasn't been scheduled yet. @tagspace approved this approach in the meantime.
