### PR TITLE
TPS-873 - Table Throwing Error on Sort

### DIFF
--- a/src/components/vanilla/charts/TableChart/index.tsx
+++ b/src/components/vanilla/charts/TableChart/index.tsx
@@ -187,7 +187,7 @@ export default (props: Props) => {
   );
 };
 
-function formatColumn(text: string | number | boolean, column: DimensionOrMeasure) {
+function formatColumn(text: string | number | boolean | null | undefined, column: DimensionOrMeasure) {
   if (text === null || text === undefined) return '-';
   if (typeof text === 'number' || column.nativeType === 'number') {
     return formatValue(`${text}`, { type: 'number', meta: column?.meta });


### PR DESCRIPTION
Fixed an issue in the table component where the client's data has `null` in what is otherwise a string column was throwing an error and breaking the table. Having `null` in a string return is slightly malformed on their part but we should still check for it. Now `null` values (and `undefined`) generate a simple `'-'` string to get inserted into the table at the appropriate place.

Reason for the error: `null` is technically an object in JavaScript, so another part of the code was seeing that and trying to look for `null.props.children` which ... isn't a thing. This is happening because the only time we send an object, it's from custom code that allows users to put markdown links into their data and have them format correctly. We could make that code more robust, but this is a one-line fix we can get in on a Friday that will solve the problem, and we're completely redoing the table component in R.UI so we'll handle it then.