### PR TITLE
Release 1.12

### DIFF
--- a/.changeset/wide-cups-act.md
+++ b/.changeset/wide-cups-act.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/vanilla-components': patch
+---
+
+Fixed an issue where in rare cases the Table Chart would crash when interpreting strings and getting a `null` value instead of an empty string.


### PR DESCRIPTION
Fixed an issue where in rare cases the Table Chart would crash when interpreting strings and getting a `null` value instead of an empty string.