### PR TITLE
CS-132 - Add Aria Labels to All Charts

### DIFF
--- a/src/components/vanilla/charts/BarChart/components/BarChart.tsx
+++ b/src/components/vanilla/charts/BarChart/components/BarChart.tsx
@@ -58,6 +58,8 @@ type Props = {
 export default function BarChart({ ...props }: Props): React.JSX.Element {
   return (
     <Chart
+      aria-label={props.title ? `Bar Chart: ${props.title}` : 'Bar Chart'}
+      aria-roledescription="bar chart"
       type="bar"
       height="100%"
       options={getBarChartOptions({ ...props, stacked: false })}

--- a/src/components/vanilla/charts/BubbleChart/index.tsx
+++ b/src/components/vanilla/charts/BubbleChart/index.tsx
@@ -84,6 +84,8 @@ export default (props: Props) => {
   return (
     <Container {...props} className="overflow-y-hidden">
       <Bubble
+        aria-label={props.title ? `Bubble Chart: ${props.title}` : 'Bubble Chart'}
+        aria-roledescription="bubble chart"
         height="100%"
         options={chartOptions(updatedProps, updatedData, bubbleData)}
         data={bubbleData}

--- a/src/components/vanilla/charts/CompareLineChart/index.tsx
+++ b/src/components/vanilla/charts/CompareLineChart/index.tsx
@@ -290,7 +290,13 @@ export default (propsInitial: Props) => {
 
   return (
     <Container {...props} className="overflow-y-hidden">
-      <Line height="100%" options={chartOptions} data={chartData} />
+      <Line
+        aria-label={props.title ? `Compare Line Chart: ${props.title}` : 'Compare Line Chart'}
+        aria-roledescription="compare line chart"
+        height="100%"
+        options={chartOptions}
+        data={chartData}
+      />
     </Container>
   );
 };

--- a/src/components/vanilla/charts/LineChart/index.tsx
+++ b/src/components/vanilla/charts/LineChart/index.tsx
@@ -228,7 +228,13 @@ export default (props: Props) => {
 
   return (
     <Container {...updatedProps} className="overflow-y-hidden">
-      <Line height="100%" options={chartOptions} data={chartData} />
+      <Line
+        aria-label={title ? `Line Chart: ${title}` : 'Line Chart'}
+        aria-roledescription="line chart"
+        height="100%"
+        options={chartOptions}
+        data={chartData}
+      />
     </Container>
   );
 };

--- a/src/components/vanilla/charts/PieChart/index.tsx
+++ b/src/components/vanilla/charts/PieChart/index.tsx
@@ -53,7 +53,8 @@ type PropsWithRequiredTheme = Props & { theme: Theme };
 type Record = { [p: string]: string };
 
 export default (props: Props) => {
-  const { results, title, enableDownloadAsCSV, maxSegments, metric, slice, onClick, granularity } = props;
+  const { results, title, enableDownloadAsCSV, maxSegments, metric, slice, onClick, granularity } =
+    props;
 
   const theme: Theme = useTheme() as Theme;
 
@@ -63,18 +64,20 @@ export default (props: Props) => {
     if (slice?.nativeType === 'time' && granularity && granularity in theme.dateFormats) {
       dateFormat = theme.dateFormats[granularity as keyof typeof theme.dateFormats];
     }
-    
-    return results?.data?.map((d) => ({
-      ...d,
-      ...(slice?.name && {
-        [slice.name]: dateFormat
-          ? formatValue(d?.[slice.name], {
-              meta: slice?.meta,
-              dateFormat,
-            })
-          : d?.[slice.name],
-      }),
-    })) ?? [];
+
+    return (
+      results?.data?.map((d) => ({
+        ...d,
+        ...(slice?.name && {
+          [slice.name]: dateFormat
+            ? formatValue(d?.[slice.name], {
+                meta: slice?.meta,
+                dateFormat,
+              })
+            : d?.[slice.name],
+        }),
+      })) ?? []
+    );
   }, [results?.data, slice, granularity, theme.dateFormats]);
   // Set ChartJS defaults
   setChartJSDefaults(theme, 'pie');
@@ -128,6 +131,8 @@ export default (props: Props) => {
   return (
     <Container {...props} className="overflow-y-hidden">
       <Pie
+        aria-label={title ? `Pie Chart: ${title}` : 'Pie Chart'}
+        aria-roledescription="pie chart"
         height="100%"
         options={chartOptions(updatedProps, theme)}
         data={chartData(updatedProps, chartColors)}
@@ -221,7 +226,9 @@ function mergeLongTail(data: any[], slice: Dimension, metric: Measure, maxSegmen
 function chartData(props: PropsWithRequiredTheme, chartColors: string[]) {
   const { maxSegments, results, metric, slice, displayAsPercentage, theme } = props;
   const labelsExceedMaxSegments = maxSegments && maxSegments < (results?.data?.length || 0);
-  const newData = labelsExceedMaxSegments ? mergeLongTail(results.data || [], slice, metric, maxSegments) : results.data;
+  const newData = labelsExceedMaxSegments
+    ? mergeLongTail(results.data || [], slice, metric, maxSegments)
+    : results.data;
 
   // Chart.js pie expects labels like so: ['US', 'UK', 'Germany']
   const labels = newData?.map((d) => d[slice.name]);

--- a/src/components/vanilla/charts/ScatterChart/index.tsx
+++ b/src/components/vanilla/charts/ScatterChart/index.tsx
@@ -82,7 +82,13 @@ export default (props: Props) => {
 
   return (
     <Container {...updatedProps} className="overflow-y-hidden">
-      <Scatter height="100%" options={chartOptions(updatedProps, scatterData)} data={scatterData} />
+      <Scatter
+        aria-label={props.title ? `Scatter Chart: ${props.title}` : 'Scatter Chart'}
+        aria-roledescription="scatter chart"
+        height="100%"
+        options={chartOptions(updatedProps, scatterData)}
+        data={scatterData}
+      />
     </Container>
   );
 };

--- a/src/components/vanilla/charts/StackedAreaChart/index.tsx
+++ b/src/components/vanilla/charts/StackedAreaChart/index.tsx
@@ -201,7 +201,7 @@ export default (props: Props) => {
   return (
     <Container {...updatedProps} className="overflow-y-hidden">
       <Line
-        aria-label={`Stacked Area Chart: ${props.title}` || 'Stacked Area Chart'}
+        aria-label={props.title ? `Stacked Area Chart: ${props.title}` : 'Stacked Area Chart'}
         aria-roledescription="stacked area chart"
         height="100%"
         options={chartOptions}

--- a/src/components/vanilla/charts/StackedAreaChart/index.tsx
+++ b/src/components/vanilla/charts/StackedAreaChart/index.tsx
@@ -200,7 +200,13 @@ export default (props: Props) => {
 
   return (
     <Container {...updatedProps} className="overflow-y-hidden">
-      <Line height="100%" options={chartOptions} data={chartData} />
+      <Line
+        aria-label={`Stacked Area Chart: ${props.title}` || 'Stacked Area Chart'}
+        aria-roledescription="stacked area chart"
+        height="100%"
+        options={chartOptions}
+        data={chartData}
+      />
     </Container>
   );
 };

--- a/src/components/vanilla/charts/StackedBarChart/index.tsx
+++ b/src/components/vanilla/charts/StackedBarChart/index.tsx
@@ -94,7 +94,7 @@ export default (props: Props) => {
   return (
     <Container {...props} className="overflow-y-hidden">
       <Bar
-        aria-label={`Stacked Bar Chart: ${props.title}` || 'Stacked Bar Chart'}
+        aria-label={props.title ? `Stacked Bar Chart: ${props.title}` : 'Stacked Bar Chart'}
         aria-roledescription="stacked bar chart"
         height="100%"
         options={getBarChartOptions({ ...updatedProps, stacked: props.stackBars, theme })}

--- a/src/components/vanilla/charts/StackedBarChart/index.tsx
+++ b/src/components/vanilla/charts/StackedBarChart/index.tsx
@@ -94,6 +94,8 @@ export default (props: Props) => {
   return (
     <Container {...props} className="overflow-y-hidden">
       <Bar
+        aria-label={`Stacked Bar Chart: ${props.title}` || 'Stacked Bar Chart'}
+        aria-roledescription="stacked bar chart"
         height="100%"
         options={getBarChartOptions({ ...updatedProps, stacked: props.stackBars, theme })}
         data={


### PR DESCRIPTION
In order to improve accessibility and allow our clients to meet certain regulatory needs, they've requested that we add Aria labels to the canvas elements (charts) on the page. This PR accomplishes that, and also adds Role Descriptions as well.

This PR has zero impact on functionality, doesn't break any existing visuals, and only applies improved accessibility standards.