### PR TITLE
CS-58 - Normalize Null Value Output in Download Button

### DIFF
--- a/src/components/vanilla/charts/DownloadButton/index.tsx
+++ b/src/components/vanilla/charts/DownloadButton/index.tsx
@@ -42,10 +42,21 @@ export default (props: Props) => {
         // We haven't finished the loadData yet, so hang on
         return;
       }
+      const cleanData = (row: DataResponseData) =>
+        Object.fromEntries(
+          Object.entries(row).map(([key, value]) => [
+            key,
+            value === null || value === 'No Value' ? '' : value,
+          ]),
+        );
+
+      const dataCleaned = results.data.map(cleanData);
+      const prevDataCleaned = results.prevData?.map(cleanData);
+
       downloadAsCSV(
         props,
-        results?.data,
-        results?.prevData,
+        dataCleaned,
+        prevDataCleaned || [],
         'downloaded-chart-data',
         setIsPreppingDownload,
       );


### PR DESCRIPTION
**Ensure null / No Value values are just an empty string in download button output**
Currently due to some other formatting, sometimes null values in the CSV output are `null` and sometimes `No Value` and sometimes an empty string. This was frustrating clients. This PR normalizes them to always be an empty string.