### PR TITLE
CS-89 - Fix and Improve Pivot Table Sort

### DIFF
--- a/src/components/util/sortFn.ts
+++ b/src/components/util/sortFn.ts
@@ -3,7 +3,7 @@ import { SortDirection } from '../../enums/SortDirection';
 export type SortCriteria<T> = {
   key: keyof T | ((item: T) => string);
   direction: SortDirection;
-}
+};
 
 function getValue<T>(item: T, key: keyof T | ((item: T) => any)): any {
   return typeof key === 'function' ? key(item) : item[key];
@@ -13,7 +13,7 @@ function isNumber(num: any): boolean {
   return !isNaN(num);
 }
 
-export const multisortFn = <T>(criteria: SortCriteria<T>[]): (a: T, b: T) => number => {
+export const multisortFn = <T>(criteria: SortCriteria<T>[]): ((a: T, b: T) => number) => {
   return (a: T, b: T): number => {
     for (const { key, direction } of criteria) {
       const aValue = getValue(a, key) || 0;
@@ -26,23 +26,28 @@ export const multisortFn = <T>(criteria: SortCriteria<T>[]): (a: T, b: T) => num
     }
     return 0;
   };
-}
+};
 
 export const basicSortFn = (a: any, b: any, sortDirection: SortDirection): number => {
+  // handle sortDirection NONE
+  if (sortDirection === SortDirection.NONE) {
+    return 0;
+  }
   if (isNumber(a) && isNumber(b)) {
     const valA = parseInt(a, 10);
     const valB = parseInt(b, 10);
 
     return (valA - valB) * (sortDirection === SortDirection.ASCENDING ? 1 : -1);
-    
   } else if (typeof a === 'string' && typeof b === 'string') {
-    return a.localeCompare(b, undefined, {
-      sensitivity: 'base',
-      numeric: true,
-    }) * (sortDirection === SortDirection.ASCENDING ? 1 : -1);
+    return (
+      a.localeCompare(b, undefined, {
+        sensitivity: 'base',
+        numeric: true,
+      }) * (sortDirection === SortDirection.ASCENDING ? 1 : -1)
+    );
   } else if (typeof a === 'number') {
     return -1; // Numbers come before strings
   } else {
     return 1; // Strings come after numbers
   }
-}
+};

--- a/src/components/vanilla/charts/PivotTable/PivotTable.emb.ts
+++ b/src/components/vanilla/charts/PivotTable/PivotTable.emb.ts
@@ -115,14 +115,14 @@ export const meta = {
     {
       name: 'rowSortDirection',
       type: SortDirectionType,
-      defaultValue: { value: SortDirection.ASCENDING },
+      defaultValue: SortDirection.NONE,
       label: 'Default Row Sort Direction',
       category: 'Chart settings',
     },
     {
       name: 'columnSortDirection',
       type: SortDirectionType,
-      defaultValue: { value: SortDirection.ASCENDING },
+      defaultValue: SortDirection.NONE,
       label: 'Default Column Sort Direction',
       category: 'Chart settings',
     },
@@ -197,17 +197,19 @@ export default defineComponent(Component, meta, {
               [`resultsDimension${index}`]: loadData({
                 from: inputs.ds,
                 select: [
-                  ...dimensionsToFetch.filter(
-                    (dimension) => dimension.nativeType !== 'time',
-                  ),
-                  ...dimensionsToFetch.filter((dimension) => dimension.nativeType === 'time')
-                  .map((timeDimension) => ({
-                    dimension: timeDimension.name,
-                    granularity: inputs.granularity,
-                  })),
+                  ...dimensionsToFetch.filter((dimension) => dimension.nativeType !== 'time'),
+                  ...dimensionsToFetch
+                    .filter((dimension) => dimension.nativeType === 'time')
+                    .map((timeDimension) => ({
+                      dimension: timeDimension.name,
+                      granularity: inputs.granularity,
+                    })),
                   ...measures,
                 ],
-                orderBy: sort.slice(0, index + 1),
+                orderBy:
+                  inputs.rowSortDirection === SortDirection.NONE
+                    ? undefined
+                    : sort.slice(0, index + 1),
                 limit: 10_000,
               }),
             };
@@ -218,11 +220,11 @@ export default defineComponent(Component, meta, {
               select: [
                 {
                   ...[...(filteredRowDimensions || []), ...columnDimensions]
-                  .filter((dimension) => dimension.nativeType === 'time')
-                  .map((timeDimension) => ({
-                    dimension: timeDimension.name,
-                    granularity: inputs.granularity,
-                  })),
+                    .filter((dimension) => dimension.nativeType === 'time')
+                    .map((timeDimension) => ({
+                      dimension: timeDimension.name,
+                      granularity: inputs.granularity,
+                    })),
                 },
                 ...measures,
               ],
@@ -234,10 +236,8 @@ export default defineComponent(Component, meta, {
       ...inputs,
       rowValues: rowValuesInputData,
       columnValues: columnDimensions,
-      // @ts-expect-error - value is set by defineComponent, may need to adjust typing in that module
-      rowSortDirection: inputs.rowSortDirection?.value,
-      // @ts-expect-error - value is set by defineComponent, may need to adjust typing in that module
-      columnSortDirection: inputs.columnSortDirection?.value,
+      rowSortDirection: inputs.rowSortDirection as SortDirection,
+      columnSortDirection: inputs.columnSortDirection as SortDirection,
       // measureVisualizationFormat: inputs.measureVisualizationFormat?.value, // Enable this after Bars mode will be fixed
       measureVisualizationFormat: MeasureVisualizationFormat.NUMERIC_VALUES_ONLY,
       aggregateRowDimensions,

--- a/src/enums/SortDirection.ts
+++ b/src/enums/SortDirection.ts
@@ -1,4 +1,5 @@
 export enum SortDirection {
   ASCENDING = 'Ascending',
-  DESCENDING = 'Descending'
+  DESCENDING = 'Descending',
+  NONE = 'None',
 }

--- a/src/types/SortDirection.type.emb.ts
+++ b/src/types/SortDirection.type.emb.ts
@@ -7,6 +7,8 @@ const SortDirectionType = defineType('sortDirection', {
   optionLabel: (direction: string) => direction,
 });
 
+defineOption(SortDirectionType, SortDirection.NONE);
+
 defineOption(SortDirectionType, SortDirection.ASCENDING);
 
 defineOption(SortDirectionType, SortDirection.DESCENDING);


### PR DESCRIPTION
Previously, the pivot table had two issues:

1. The "default sort" dropdowns each included a blank item
2. No matter what you chose, it always sorted ascending

I've adjusted the pivot table to do the following:

1. Get rid of the blank item
2. Allow choices of "none", "ascending", or "descending"
3. Default to "none"
4. Respect the choice when the table is operating

This should not break any existing dashboards as those will all already have custom sort values set.

Here's a quick video showing all three sort states working:

https://www.loom.com/share/c7c4c798ebce43d694a1e630ec02aabc?sid=69254993-6b04-4b61-9919-245489973bd9