### PR TITLE
CS-143 - Bar Chart Limits

### DIFF
--- a/src/components/vanilla/charts/BarChart/BarChart.emb.ts
+++ b/src/components/vanilla/charts/BarChart/BarChart.emb.ts
@@ -202,7 +202,7 @@ export default defineComponent(Component, meta, {
         from: inputs.ds,
         select: [...dimensions, ...measures],
         orderBy: orderProp,
-        limit: inputs.limit || 50,
+        limit: inputs.limit || 100,
       }),
     };
   },


### PR DESCRIPTION
Add default limit to bar chart for clarity - the limit input is already there, but it's empty by default. Nonetheless, the bar chart limits to 100 by default. Changed it to `100` so that it's clear.