### PR TITLE
Fix date formatting for bar chart breaking custom area chart

### DIFF
--- a/src/components/util/format.ts
+++ b/src/components/util/format.ts
@@ -24,16 +24,16 @@ const dateFormatter = new Intl.DateTimeFormat();
 
 /**
  * Formats a value according to the specified options
- * 
+ *
  * Runtime assumptions:
  * - Metrics are always numeric and should be formatted as numbers
  * - Date strings should be in ISO format or end with 'T00:00:00.000'
  * - DateFormat should be pre-calculated based on granularity and theme before calling this function
  * - Meta objects may contain pretext/posttext for value wrapping
- * 
+ *
  * Note: Granularity-based formatting is handled at the component level where theme is available.
  * This function expects the dateFormat to be pre-calculated and passed in the options.
- * 
+ *
  * @param str - The string value to format
  * @param opt - Formatting options or type
  * @returns The formatted value as a string

--- a/src/components/util/getStackedChartData.ts
+++ b/src/components/util/getStackedChartData.ts
@@ -97,17 +97,24 @@ export default function getStackedChartData(
   let dateFormat: string | undefined = undefined;
   if (useCustomDateFormat && granularity) {
     dateFormat = theme.dateFormats[granularity];
-  }
-  else if (xAxis.nativeType === 'time') {
+  } else if (xAxis.nativeType === 'time' && options?.chartType !== 'stackedAreaChart') {
     if (granularity && theme.dateFormats[granularity]) {
       dateFormat = theme.dateFormats[granularity];
-    } else if (xAxis?.inputs?.granularity && theme.dateFormats[xAxis.inputs.granularity as Granularity]) {
+    } else if (
+      xAxis?.inputs?.granularity &&
+      theme.dateFormats[xAxis.inputs.granularity as Granularity]
+    ) {
       dateFormat = theme.dateFormats[xAxis.inputs.granularity as Granularity];
     }
   }
 
   return {
-    labels: labels.map((l) => formatValue(l, { meta: xAxis?.meta, dateFormat: dateFormat })),
+    labels: labels.map((l) =>
+      formatValue(l, {
+        meta: xAxis?.meta,
+        dateFormat,
+      }),
+    ),
     datasets: segments.map((s, i) => {
       const dataset = {
         ...datasetsMeta,

--- a/src/themes/defaulttheme.ts
+++ b/src/themes/defaulttheme.ts
@@ -131,7 +131,7 @@ export const defaultTheme: Theme = {
       },
     },
     stackedArea: {
-      cubicInterpolationMode: 'default',
+      cubicInterpolationMode: 'monotone',
       font: {
         size: 12,
       },


### PR DESCRIPTION
This is a very minor fix - some logic introduced to help the Stacked Bar Chart component format dates is conflicting with how the Stacked Area Chart component formats dates, and causing it to just flat-out not render in certain situations. A single line change to check for chart type fixes the problem and allows both charts to work (see screenshot). The other file changes are just fixing an incorrect theme value and some Prettier edits to formatting.

<img width="1432" height="647" alt="image" src="https://github.com/user-attachments/assets/e18efb93-368e-4eef-83ab-8f1fd9c058d0" />
