### PR TITLE
Release 1.1.7

### DIFF
--- a/.changeset/tired-pillows-fail.md
+++ b/.changeset/tired-pillows-fail.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/vanilla-components': patch
+---
+
+Explicit bar chart default limit, fixed stacked area chart


### PR DESCRIPTION
- Updated Bar Chart "limit" input to properly reflect the existing default
- Fixed a bug that was causing the stacked area chart to render a blank canvas in certain circumstances