### PR TITLE
CS-137 - Heat Grid Sizing Issues

### DIFF
--- a/src/components/vanilla/charts/HeatGrid/index.tsx
+++ b/src/components/vanilla/charts/HeatGrid/index.tsx
@@ -239,7 +239,7 @@ const HeatGrid: React.FC<Props> = (props) => {
         </div>
         <div className="flex justify-between items-center w-full">
           {displayLegend && (
-            <div className="flex justify-between items-center">
+            <div className="flex justify-between items-center pr-2">
               <div style={{ ...CELL_STYLE, width: '24px' }}>Less</div>
               {generateBox(baseColor ? baseColor : theme.brand.primary, BASE_OPACITY, CELL_STYLE)}
               {generateBox(baseColor ? baseColor : theme.brand.primary, 0.4, CELL_STYLE)}

--- a/src/components/vanilla/charts/HeatGrid/index.tsx
+++ b/src/components/vanilla/charts/HeatGrid/index.tsx
@@ -215,7 +215,7 @@ const HeatGrid: React.FC<Props> = (props) => {
               Sun
             </div>
           </div>
-          <div className="flex flow-grow overflow-auto">
+          <div className="flex flex-grow overflow-auto">
             {dataToDisplay.length > 0 &&
               dataToDisplay.map((week, weekIndex) => (
                 <div key={weekIndex} className="flex flex-col">

--- a/src/components/vanilla/charts/HeatGrid/index.tsx
+++ b/src/components/vanilla/charts/HeatGrid/index.tsx
@@ -190,7 +190,7 @@ const HeatGrid: React.FC<Props> = (props) => {
     <Container {...props} className="overflow-y-hidden">
       <div className="flex flex-col items-left">
         <div
-          className={`flex flex-wrap ${displayLegend || displayStats ? 'border-b-2 mb-2 pb-2' : null} border-gray-200 `}
+          className={`flex flex-nowrap ${displayLegend || displayStats ? 'border-b-2 mb-2 pb-2' : null} border-gray-200 `}
         >
           <div className="flex flex-col items-center">
             <div className="text-xs" style={{ ...CELL_STYLE, width: '24px', textAlign: 'right' }}>
@@ -215,25 +215,27 @@ const HeatGrid: React.FC<Props> = (props) => {
               Sun
             </div>
           </div>
-          {dataToDisplay.length > 0 &&
-            dataToDisplay.map((week, weekIndex) => (
-              <div key={weekIndex} className="flex flex-col">
-                {week.map((day: { value: number; date: string }, dayIndex: number) => (
-                  <div
-                    key={`${weekIndex}-${dayIndex}`}
-                    style={{
-                      ...CELL_STYLE,
-                      backgroundColor: getColor(day.value),
-                      border:
-                        day.value < 0
-                          ? `1px solid ${hexToRgb(baseColor ? baseColor : theme.brand.primary, BASE_OPACITY)}`
-                          : 'none',
-                    }}
-                    title={`${day.date}: ${day.value}`}
-                  />
-                ))}
-              </div>
-            ))}
+          <div className="flex flow-grow overflow-auto">
+            {dataToDisplay.length > 0 &&
+              dataToDisplay.map((week, weekIndex) => (
+                <div key={weekIndex} className="flex flex-col">
+                  {week.map((day: { value: number; date: string }, dayIndex: number) => (
+                    <div
+                      key={`${weekIndex}-${dayIndex}`}
+                      style={{
+                        ...CELL_STYLE,
+                        backgroundColor: getColor(day.value),
+                        border:
+                          day.value < 0
+                            ? `1px solid ${hexToRgb(baseColor ? baseColor : theme.brand.primary, BASE_OPACITY)}`
+                            : 'none',
+                      }}
+                      title={`${day.date}: ${day.value}`}
+                    />
+                  ))}
+                </div>
+              ))}
+          </div>
         </div>
         <div className="flex justify-between items-center w-full">
           {displayLegend && (


### PR DESCRIPTION
The current version of the Heat Grid looks great as long as your container is wide enough to accommodate the data. When the data is too long, it breaks terribly, overflowing vertically and then getting clipped. This minor update allows it to scroll horizontally while keeping the left-hand labels visible. Works much better in small containers and/or Custom Canvas.

This is 100% backwards compatible for people already using the heat grid. It changes nothing visually except to fix the breaking overflow issue.

<img width="371" height="317" alt="image" src="https://github.com/user-attachments/assets/6d72af26-ab42-4750-9e96-de41d9815096" />
