### PR TITLE
CS-153 - Replace All Error

### DIFF
--- a/src/models/cubes/customers.cube.yml
+++ b/src/models/cubes/customers.cube.yml
@@ -28,13 +28,6 @@ cubes:
       - name: signed_up_at
         sql: signed_up_at
         type: time
-        granularities:
-          - name: quarter_hour
-            interval: 15 minutes
-
-          - name: week_starting_on_sunday
-            interval: 1 week
-            offset: -1 day
 
       # - name: full_name
       #   title: "Full name"

--- a/src/models/cubes/orders.cube.yml
+++ b/src/models/cubes/orders.cube.yml
@@ -13,6 +13,14 @@ cubes:
         sql: created_at
         type: time
         description: 'The time when the order was created'
+        # optional - define additional custom time intervals (granularities)
+        granularities:
+          - name: quarter_hour
+            interval: 15 minutes
+
+          - name: week_starting_on_sunday
+            interval: 1 week
+            offset: -1 day
 
     measures:
       - name: count


### PR DESCRIPTION
A call to `replaceAll` used to help implement custom granularities was breaking the dropdown on non-string values. This PR addresses the issue, ensuring that the method is only called on string values.